### PR TITLE
Let users edit & delete their own quotes 

### DIFF
--- a/commands/deletequote.js
+++ b/commands/deletequote.js
@@ -30,7 +30,7 @@ module.exports = {
 				.setRequired(true)
 		),
 	cooldown: 8,
-	permission: "manage",
+	permission: "manageSelf",
 	async execute(interaction) {
 		const id = interaction.options.getInteger("id");
 		const guild = await Guild.findOneAndUpdate(

--- a/commands/editquote.js
+++ b/commands/editquote.js
@@ -43,7 +43,7 @@ module.exports = {
 		),
 	cooldown: 10,
 	guildOnly: true,
-	permission: "manage",
+	permission: "manageSelf",
 	async execute(interaction) {
 		interaction.deferReply({ ephemeral: true });
 		const quoteID = interaction.options.getInteger("id");

--- a/commands/manageself.js
+++ b/commands/manageself.js
@@ -1,0 +1,54 @@
+/*
+Copyright (C) 2020-2021 Nicholas Christopher
+
+This file is part of Quoter.
+
+Quoter is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3.
+
+Quoter is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Quoter.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+const { SlashCommandBuilder } = require("@discordjs/builders");
+const Guild = require("../schemas/guild.js");
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName("manageself")
+		.setDescription(
+			"Toggles whether users can delete/edit quotes they created."
+		),
+	cooldown: 3,
+	permission: "manage",
+	async execute(interaction) {
+		const currentState = (await Guild.findById(interaction.guild.id))
+			?.manageSelf;
+
+		await Guild.findOneAndUpdate(
+			{ _id: interaction.guild.id },
+			{ manageSelf: !currentState },
+			{
+				upsert: true,
+			}
+		);
+
+		if (currentState) {
+			await interaction.reply({
+				content:
+					"✅ **|** Users __can no longer__ delete or edit quotes they've created..",
+			});
+		} else {
+			await interaction.reply({
+				content:
+					"✅ **|** Users __can now__ delete or edit quotes they've created.",
+			});
+		}
+	},
+};

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -92,6 +92,25 @@ module.exports = {
 						ephemeral: true,
 					});
 				}
+			} else if (command.permission === "manageSelf") {
+				const { manageSelf, quotes } = await Guild.findOneAndUpdate(
+					{ _id: interaction.guild.id },
+					{},
+					{ upsert: true, new: true }
+				);
+
+				const id = interaction.options.getInteger("id");
+				const createdQuote =
+					quotes[id - 1]?.quoterID === interaction.user.id;
+
+				if (!isManager && !(manageSelf && createdQuote)) {
+					return await interaction.reply({
+						content: `✋ **|** That action requires the **Manage Guild** permission.
+		
+**❗ To allow users to delete/edit quotes they've created**, have an admin use \`/manageself\`.`,
+						ephemeral: true,
+					});
+				}
 			} else if (command.permission === "manage") {
 				if (!isManager) {
 					return await interaction.reply({

--- a/schemas/guild.js
+++ b/schemas/guild.js
@@ -25,6 +25,7 @@ const guildSchema = new Schema({
 	},
 	prefix: String,
 	allQuote: Boolean,
+	manageSelf: Boolean,
 	maxGuildQuotes: Number,
 	maxQuoteLength: Number,
 	quotes: [


### PR DESCRIPTION
This PR allows users to edit & delete their own quotes __by default__, with a toggle (`/manageself`) for servers. 

- [x] Add `manageSelf` Boolean to Guild schema.
- [x] Add command (`/manageSelf`) for toggling functionality.
- [x] Implement in permissions system. 