### PR TITLE
Option to set author as user in /newquote

### DIFF
--- a/commands/newquote.js
+++ b/commands/newquote.js
@@ -19,7 +19,6 @@ along with Quoter.  If not, see <https://www.gnu.org/licenses/>.
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { MessageEmbed } = require("discord.js");
 const Guild = require("../schemas/guild.js");
-const mentionParse = require("../util/mentionParse.js");
 const cleanString = require("../util/cleanString.js");
 const { maxGuildQuotes, maxQuoteLength } = require("../config.json");
 
@@ -33,8 +32,11 @@ module.exports = {
 				.setDescription("The quote's text.")
 				.setRequired(true)
 		)
+		.addUserOption((o) =>
+			o.setName("author_user").setDescription("User that said the quote. This option will take precedent over author_name.")
+		)
 		.addStringOption((o) =>
-			o.setName("author").setDescription("The quote's author.")
+			o.setName("author_name").setDescription("Name of the person that said the quote.")
 		),
 	cooldown: 10,
 	guildOnly: true,
@@ -61,8 +63,15 @@ module.exports = {
 			});
 		}
 
-		let author = interaction.options.getString("author");
-		author &&= await mentionParse(author);
+		let author = interaction.options.getUser("author_user"); // user if specific
+		if(!author) {
+			if(interaction.options.getString("author_name")) {
+				author &&= interaction.options.getString("author_name") // user string if specified
+			}
+			else {
+				author = interaction.author.tag; // user that used the command if no author_name or author_user
+			}
+		};
 
 		const text = interaction.options.getString("text");
 

--- a/config.json.EXAMPLE
+++ b/config.json.EXAMPLE
@@ -1,6 +1,6 @@
 {
-	"token": "TOKEN",
-	"mongoPath": "mongodb://127.0.0.1:27017/quoter",
+	"token": "",
+	"mongoPath": "",
 	"maxGuildQuotes": 75,
 	"maxQuoteLength": 130,
 	"admins": [],


### PR DESCRIPTION
`/newquote` now has two optional options, one of which is a user option, and the other is a string option. Users can enter either one, and the user option will take precedent over the other if they are both filled in. If neither are filled in, it will use the person creating the quote.